### PR TITLE
Add support for setting fallback values for options through ini file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,18 @@ Shows failed tests like so::
     text going to stderr
     ==================== 2 failed in 0.02 seconds =====================
 
+These options can also be customized through a configuration file::
+
+    [pytest]
+    log_format = %(asctime)s %(levelname)s %(message)s
+    log_date_format = %Y-%m-%d %H:%M:%S
+
+Although the same effect could be achieved through the ``addopts`` setting,
+using dedicated options should be preferred since the latter doesn't
+force other developers to have ``pytest-catchlog`` installed (while at
+the same time, ``addopts`` approach would fail with 'unrecognized arguments'
+error). Command line arguments take precedence.
+
 Further it is possible to disable reporting logs on failed tests
 completely with::
 


### PR DESCRIPTION
That is, `--log-format` option maps to `log_format` setting within `[pytest]` section of pytest.ini / tox.ini / setup.cfg, and `--log-date-format` - to `log_date_format`.

Now, instead of writing:

```
[pytest]
addopts = --log-format='%(message)s ...'
```

One can set the `log_format` directly:

```
[pytest]
log_format = %(message)s ...
```

The advantage of the latter is that the `addopts` approach forces end users to have pytest-catchlog installed, because otherwise pytest invocation fails with `unrecognized arguments` error. In case of using `log_format = ...` everything works fine as if there was no such option.

I believe, such behavior should be implemented and handled by pytest itself, but still...
