### PR TITLE
Make caplog.text, .records and .record_tuples properties and restore backward compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,9 +119,9 @@ the contents of a message::
 
     def test_baz(caplog):
         func_under_test()
-        for record in caplog.records():
+        for record in caplog.records:
             assert record.levelname != 'CRITICAL'
-        assert 'wally' not in caplog.text()
+        assert 'wally' not in caplog.text
 
 For all the available attributes of the log records see the
 ``logging.LogRecord`` class.
@@ -133,7 +133,7 @@ given severity and message::
     def test_foo(caplog):
         logging.getLogger().info('boo %s', 'arg')
 
-        assert caplog.record_tuples() == [
+        assert caplog.record_tuples == [
             ('root', logging.INFO, 'boo arg'),
         ]
 

--- a/pytest_catchlog.py
+++ b/pytest_catchlog.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
+import functools
 import logging
 from contextlib import closing, contextmanager
 
@@ -188,16 +189,17 @@ class LogCaptureFixture(object):
         """Creates a new funcarg."""
         self._item = item
 
+    @property
     def text(self):
         """Returns the log text."""
-
         return self.handler.stream.getvalue()
 
+    @property
     def records(self):
         """Returns the list of log records."""
-
         return self.handler.records
 
+    @property
     def record_tuples(self):
         """Returns a list of a striped down version of log records intended
         for use in assertion comparison.
@@ -206,7 +208,7 @@ class LogCaptureFixture(object):
 
             (logger_name, log_level, message)
         """
-        return [(r.name, r.levelno, r.getMessage()) for r in self.records()]
+        return [(r.name, r.levelno, r.getMessage()) for r in self.records]
 
     def set_level(self, level, logger=None):
         """Sets the level for capturing of logs.
@@ -231,8 +233,48 @@ class LogCaptureFixture(object):
         return logging_at_level(level, obj)
 
 
+class CallablePropertyMixin(object):
+    """Backward compatibility for functions that became properties."""
+
+    @classmethod
+    def compat_property(cls, func):
+        if isinstance(func, property):
+            make_property = func.getter
+            func = func.fget
+        else:
+            make_property = property
+
+        @functools.wraps(func)
+        def getter(self):
+            return cls(func(self))
+
+        return make_property(getter)
+
+    def __call__(self):
+        # TODO: emit a DeprecationWarning in future?
+        return self
+
+class CallableList(CallablePropertyMixin, list):
+    pass
+
+class CallableStr(CallablePropertyMixin, str):
+    pass
+
+
 class CompatLogCaptureFixture(LogCaptureFixture):
     """Backward compatibility with pytest-capturelog."""
+
+    @CallableStr.compat_property
+    def text(self):
+        return super(CompatLogCaptureFixture, self).text
+
+    @CallableList.compat_property
+    def records(self):
+        return super(CompatLogCaptureFixture, self).records
+
+    @CallableList.compat_property
+    def record_tuples(self):
+        return super(CompatLogCaptureFixture, self).record_tuples
 
     def setLevel(self, level, logger=None):
         return self.set_level(level, logger)

--- a/pytest_catchlog.py
+++ b/pytest_catchlog.py
@@ -231,6 +231,16 @@ class LogCaptureFixture(object):
         return logging_at_level(level, obj)
 
 
+class CompatLogCaptureFixture(LogCaptureFixture):
+    """Backward compatibility with pytest-capturelog."""
+
+    def setLevel(self, level, logger=None):
+        return self.set_level(level, logger)
+
+    def atLevel(self, level, logger=None):
+        return self.at_level(level, logger)
+
+
 @pytest.fixture
 def caplog(request):
     """Access and control log capturing.
@@ -241,6 +251,6 @@ def caplog(request):
     * caplog.records()       -> list of logging.LogRecord instances
     * caplog.record_tuples() -> list of (logger_name, level, message) tuples
     """
-    return LogCaptureFixture(request.node)
+    return CompatLogCaptureFixture(request.node)
 
 capturelog = caplog

--- a/test_pytest_catchlog.py
+++ b/test_pytest_catchlog.py
@@ -151,9 +151,9 @@ def test_log_access(testdir):
 
         def test_foo(caplog):
             logging.getLogger().info('boo %s', 'arg')
-            assert caplog.records()[0].levelname == 'INFO'
-            assert caplog.records()[0].msg == 'boo %s'
-            assert 'boo arg' in caplog.text()
+            assert caplog.records[0].levelname == 'INFO'
+            assert caplog.records[0].msg == 'boo %s'
+            assert 'boo arg' in caplog.text
         ''')
     result = testdir.runpytest()
     assert result.ret == 0
@@ -172,7 +172,7 @@ def test_record_tuples(testdir):
         def test_foo(caplog):
             logging.getLogger().info('boo %s', 'arg')
 
-            assert caplog.record_tuples() == [
+            assert caplog.record_tuples == [
                 ('root', logging.INFO, 'boo arg'),
             ]
         ''')
@@ -196,6 +196,22 @@ def test_compat_camel_case_aliases(testdir):
 
     py.test.raises(Exception, result.stdout.fnmatch_lines,
                    ['*- Captured *log call -*'])
+
+
+def test_compat_properties(testdir):
+    testdir.makepyfile('''
+        import logging
+
+        def test_foo(caplog):
+            logging.getLogger().info('boo %s', 'arg')
+
+            assert caplog.text    == caplog.text()    == str(caplog.text)
+            assert caplog.records == caplog.records() == list(caplog.records)
+            assert (caplog.record_tuples ==
+                    caplog.record_tuples() == list(caplog.record_tuples))
+        ''')
+    result = testdir.runpytest()
+    assert result.ret == 0
 
 
 def test_disable_log_capturing(testdir):

--- a/test_pytest_catchlog.py
+++ b/test_pytest_catchlog.py
@@ -197,6 +197,14 @@ def test_compat_camel_case_aliases(testdir):
     py.test.raises(Exception, result.stdout.fnmatch_lines,
                    ['*- Captured *log call -*'])
 
+    result = testdir.runpytest('-rw')
+    assert result.ret == 0
+    result.stdout.fnmatch_lines('''
+        =*warning summary*=
+        *WL1*test_compat_camel_case_aliases*caplog.setLevel()*deprecated*
+        *WL1*test_compat_camel_case_aliases*caplog.atLevel()*deprecated*
+    ''')
+
 
 def test_compat_properties(testdir):
     testdir.makepyfile('''
@@ -212,6 +220,15 @@ def test_compat_properties(testdir):
         ''')
     result = testdir.runpytest()
     assert result.ret == 0
+
+    result = testdir.runpytest('-rw')
+    assert result.ret == 0
+    result.stdout.fnmatch_lines('''
+        =*warning summary*=
+        *WL1*test_compat_properties*caplog.text()*deprecated*
+        *WL1*test_compat_properties*caplog.records()*deprecated*
+        *WL1*test_compat_properties*caplog.record_tuples()*deprecated*
+    ''')
 
 
 def test_disable_log_capturing(testdir):

--- a/test_pytest_catchlog.py
+++ b/test_pytest_catchlog.py
@@ -180,6 +180,24 @@ def test_record_tuples(testdir):
     assert result.ret == 0
 
 
+def test_compat_camel_case_aliases(testdir):
+    testdir.makepyfile('''
+        import logging
+
+        def test_foo(caplog):
+            caplog.setLevel(logging.INFO)
+            logging.getLogger().debug('boo!')
+
+            with caplog.atLevel(logging.WARNING):
+                logging.getLogger().info('catch me if you can')
+        ''')
+    result = testdir.runpytest()
+    assert result.ret == 0
+
+    py.test.raises(Exception, result.stdout.fnmatch_lines,
+                   ['*- Captured *log call -*'])
+
+
 def test_disable_log_capturing(testdir):
     testdir.makepyfile('''
         import sys


### PR DESCRIPTION
Slightly improve the API by making `caplog.text`, `caplog.records` and `caplog.record_tuples` properties while preserving backward compatibility, and also restore `caplog.atLevel()` and `caplog.setLevel()` back (as aliases for their snake_case counterparts).
