### PR TITLE
Restore Python 2.6 compatibility

### DIFF
--- a/pytest_catchlog.py
+++ b/pytest_catchlog.py
@@ -64,11 +64,11 @@ def catching_logs(handler, filter=None, formatter=None,
         handler.setFormatter(formatter)
     handler.setLevel(level)
 
-    with closing(handler), \
-            logging_using_handler(handler, logger), \
-            logging_at_level(min(handler.level, logger.level), logger):
+    with closing(handler):
+        with logging_using_handler(handler, logger):
+            with logging_at_level(min(handler.level, logger.level), logger):
 
-        yield handler
+                yield handler
 
 
 def add_option_ini(parser, option, dest, default=None, help=None):


### PR DESCRIPTION
Release 1.2.0 broke Python 2.6 compatibility. As there is only one statement in the module that is not compatible, I think it is worth to alter it restoring the Python 2.6 compatibility and allowing the user to run tests on that python version for some more time.
