### PR TITLE
compat: Let legacy clients modify caplog.records()

### DIFF
--- a/pytest_catchlog.py
+++ b/pytest_catchlog.py
@@ -246,7 +246,9 @@ class CallablePropertyMixin(object):
 
         @functools.wraps(func)
         def getter(self):
-            ret = cls(func(self))
+            naked_value = func(self)
+            ret = cls(naked_value)
+            ret._naked_value = naked_value
             ret._warn_compat = self._warn_compat
             ret._prop_name = func.__name__
             return ret
@@ -256,7 +258,7 @@ class CallablePropertyMixin(object):
     def __call__(self):
         self._warn_compat(old="'caplog.{0}()' syntax".format(self._prop_name),
                           new="'caplog.{0}' property".format(self._prop_name))
-        return self
+        return self._naked_value  # to let legacy clients modify the object
 
 class CallableList(CallablePropertyMixin, list):
     pass

--- a/test_pytest_catchlog.py
+++ b/test_pytest_catchlog.py
@@ -231,6 +231,29 @@ def test_compat_properties(testdir):
     ''')
 
 
+def test_compat_records_modification(testdir):
+    testdir.makepyfile('''
+        import logging
+
+        logger = logging.getLogger()
+
+        def test_foo(caplog):
+            logger.info('boo %s', 'arg')
+            assert caplog.records
+            assert caplog.records()
+
+            del caplog.records()[:]  # legacy syntax
+            assert not caplog.records
+            assert not caplog.records()
+
+            logger.info('foo %s', 'arg')
+            assert caplog.records
+            assert caplog.records()
+        ''')
+    result = testdir.runpytest()
+    assert result.ret == 0
+
+
 def test_disable_log_capturing(testdir):
     testdir.makepyfile('''
         import sys


### PR DESCRIPTION
Some (maybe lots of) existing projects using pytest-capturelog, used to flush records buffer through a direct access to the list:

```
del caplog.records()[:]
```

This is the only available way to do that so far, in fact.

Fixes #18 ("#11 introduces subtle incompatibility"). Thanks @mnencia for reporting.
