### PR TITLE
Include tests in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include MANIFEST.in Makefile LICENSE.txt README.rst CHANGES.rst setup.cfg
+include test_pytest_catchlog.py
 
 global-exclude *pyc
 prune __pycache__


### PR DESCRIPTION
This fixes #13 once it has been merged. This is a rather low hanging fruit. 

Without the given line the content of the source distribution equals to

```
Archive:  dist/pytest-catchlog-1.2.0.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      105  2015-11-15 23:13   pytest-catchlog-1.2.0/setup.cfg
     1321  2015-11-15 23:04   pytest-catchlog-1.2.0/CHANGES.rst
     6945  2015-11-15 23:13   pytest-catchlog-1.2.0/PKG-INFO
      665  2015-10-03 20:29   pytest-catchlog-1.2.0/Makefile
      113  2015-11-15 23:13   pytest-catchlog-1.2.0/MANIFEST.in
     9505  2015-11-15 23:04   pytest-catchlog-1.2.0/pytest_catchlog.py
     1135  2014-12-08 19:34   pytest-catchlog-1.2.0/LICENSE.txt
     4701  2015-11-08 22:53   pytest-catchlog-1.2.0/README.rst
     2015  2015-11-15 23:04   pytest-catchlog-1.2.0/setup.py
      367  2015-11-15 23:13   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/SOURCES.txt
       22  2015-11-15 23:13   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/requires.txt
     6945  2015-11-15 23:13   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/PKG-INFO
        1  2015-11-15 23:13   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/not-zip-safe
       46  2015-11-15 23:13   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/entry_points.txt
       16  2015-11-15 23:13   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/top_level.txt
        1  2015-11-15 23:13   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/dependency_links.txt
---------                     -------
    33903                     16 files
```

And with this change the archive content looks like this:

```
Archive:  dist/pytest-catchlog-1.2.0.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      105  2015-11-15 23:12   pytest-catchlog-1.2.0/setup.cfg
     1321  2015-11-15 23:04   pytest-catchlog-1.2.0/CHANGES.rst
     6945  2015-11-15 23:12   pytest-catchlog-1.2.0/PKG-INFO
      665  2015-10-03 20:29   pytest-catchlog-1.2.0/Makefile
      145  2015-11-15 23:10   pytest-catchlog-1.2.0/MANIFEST.in
     9505  2015-11-15 23:04   pytest-catchlog-1.2.0/pytest_catchlog.py
     8478  2015-11-08 22:53   pytest-catchlog-1.2.0/test_pytest_catchlog.py  <<<---- It's there!
     1135  2014-12-08 19:34   pytest-catchlog-1.2.0/LICENSE.txt
     4701  2015-11-08 22:53   pytest-catchlog-1.2.0/README.rst
     2015  2015-11-15 23:04   pytest-catchlog-1.2.0/setup.py
      391  2015-11-15 23:12   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/SOURCES.txt
       22  2015-11-15 23:12   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/requires.txt
     6945  2015-11-15 23:12   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/PKG-INFO
        1  2015-11-15 23:12   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/not-zip-safe
       46  2015-11-15 23:12   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/entry_points.txt
       16  2015-11-15 23:12   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/top_level.txt
        1  2015-11-15 23:12   pytest-catchlog-1.2.0/pytest_catchlog.egg-info/dependency_links.txt
---------                     -------
    42437                     17 files
```

I was tempted to commit this directly to develop but I wanted to have this change documented to clarify that this will really include the test suite. Setuptools lacks some introspection abilities to easily debug these cases.
