### PR TITLE
Deprecation warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,23 @@ Yet to be released.
 
 - [Bugfix] #15 #17 - Restore Python 2.6 compatibility. (Thanks to Marco Nenciarini!)
 
+.. attention::
+    Deprecation warning: the following objects (i.e. functions, properties)
+    are slated for removal in the next major release.
+
+    - ``caplog.at_level`` and ``caplog.set_level`` should be used instead of
+      ``caplog.atLevel`` and ``caplog.setLevel``.
+
+      The methods ``caplog.atLevel`` and ``caplog.setLevel`` are still
+      available but deprecated and not supported since they don't follow
+      the PEP8 convention for method names.
+
+    - ``caplog.text``, ``caplog.records`` and
+      ``caplog.record_tuples`` were turned into properties.
+      They still can be used as regular methods for backward compatibility,
+      but that syntax is considered deprecated and scheduled for removal in
+      the next major release.
+
 
 Version 1.2
 -----------

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(name='pytest-catchlog',
       version=_get_version(),
       description=('py.test plugin to catch log messages.'
                    ' This is a fork of pytest-capturelog.'),
-      long_description=_read_text_file('README.rst'),
+      long_description='\n'.join([_read_text_file('README.rst'),
+                                  _read_text_file('CHANGES.rst'), ]),
       author='Arthur Skowronek (Fork Author)',  # original author: Meme Dough
       author_email='eisensheng@mailbox.org',
       url='https://github.com/eisensheng/pytest-catchlog',


### PR DESCRIPTION
This adds a longer paragraph regarding the deprecation phase for the changed methods. The `CHANGES.rst` file will also be included in the `long_description` for the `setup.py` file to warn users only reading the PYPI page.

Would be nice to have this reviewed before it lands in develop. English is not my mother language after all. I hate to state this but this makes it a requirement that other review my text IMHO. Thanks!
