### PR TITLE
Dedicated caplog recording handler

### DIFF
--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -61,7 +61,7 @@ class LogCaptureFixture(object):
 
             (logger_name, log_level, message)
         """
-        return [(r.name, r.levelno, r.getMessage()) for r in self.records]
+        return [(r.name, r.levelno, r.message) for r in self.records]
 
     def set_level(self, level, logger=None):
         """Sets the level for capturing of logs.

--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -13,27 +13,25 @@ from pytest_catchlog.common import catching_logs, logging_at_level
 BASIC_FORMATTER = logging.Formatter(logging.BASIC_FORMAT)
 
 
-class LogCaptureHandler(logging.StreamHandler):
+class RecordingHandler(logging.StreamHandler,
+                       object):  # Python 2.6: enforce new-style class
     """A logging handler that stores log records and the log text."""
 
     def __init__(self):
         """Creates a new log handler."""
-
-        logging.StreamHandler.__init__(self)
+        super(RecordingHandler, self).__init__()
         self.stream = py.io.TextIO()
         self.records = []
 
     def close(self):
         """Close this log handler and its underlying stream."""
-
-        logging.StreamHandler.close(self)
+        super(RecordingHandler, self).close()
         self.stream.close()
 
     def emit(self, record):
         """Keep the log records in a list in addition to the log text."""
-
+        super(RecordingHandler, self).emit(record)
         self.records.append(record)
-        logging.StreamHandler.emit(self, record)
 
 
 class LogCaptureFixture(object):
@@ -170,7 +168,7 @@ def caplog(request):
     * caplog.records()       -> list of logging.LogRecord instances
     * caplog.record_tuples() -> list of (logger_name, level, message) tuples
     """
-    with catching_logs(LogCaptureHandler(),
+    with catching_logs(RecordingHandler(),
                        formatter=BASIC_FORMATTER) as handler:
         yield CompatLogCaptureFixture(handler, item=request.node)
 

--- a/pytest_catchlog/plugin.py
+++ b/pytest_catchlog/plugin.py
@@ -12,6 +12,7 @@ from pytest_catchlog.common import catching_logs
 
 # Let the fixtures be discoverable by pytest.
 from pytest_catchlog.fixture import caplog, capturelog
+from pytest_catchlog.fixture import LogCaptureHandler
 
 
 DEFAULT_LOG_FORMAT = '%(filename)-25s %(lineno)4d %(levelname)-8s %(message)s'
@@ -85,11 +86,7 @@ class CatchLogPlugin(object):
         """Implements the internals of pytest_runtest_xxx() hook."""
         with catching_logs(LogCaptureHandler(),
                            formatter=self.formatter) as log_handler:
-            item.catch_log_handler = log_handler
-            try:
-                yield  # run test
-            finally:
-                del item.catch_log_handler
+            yield  # run test
 
             if self.print_logs:
                 # Add a captured log section to the report.
@@ -110,26 +107,3 @@ class CatchLogPlugin(object):
     def pytest_runtest_teardown(self, item):
         with self._runtest_for(item, 'teardown'):
             yield
-
-
-class LogCaptureHandler(logging.StreamHandler):
-    """A logging handler that stores log records and the log text."""
-
-    def __init__(self):
-        """Creates a new log handler."""
-
-        logging.StreamHandler.__init__(self)
-        self.stream = py.io.TextIO()
-        self.records = []
-
-    def close(self):
-        """Close this log handler and its underlying stream."""
-
-        logging.StreamHandler.close(self)
-        self.stream.close()
-
-    def emit(self, record):
-        """Keep the log records in a list in addition to the log text."""
-
-        self.records.append(record)
-        logging.StreamHandler.emit(self, record)

--- a/pytest_catchlog/plugin.py
+++ b/pytest_catchlog/plugin.py
@@ -12,7 +12,6 @@ from pytest_catchlog.common import catching_logs
 
 # Let the fixtures be discoverable by pytest.
 from pytest_catchlog.fixture import caplog, capturelog
-from pytest_catchlog.fixture import LogCaptureHandler
 
 
 DEFAULT_LOG_FORMAT = '%(filename)-25s %(lineno)4d %(levelname)-8s %(message)s'
@@ -84,13 +83,14 @@ class CatchLogPlugin(object):
     @contextmanager
     def _runtest_for(self, item, when):
         """Implements the internals of pytest_runtest_xxx() hook."""
-        with catching_logs(LogCaptureHandler(),
-                           formatter=self.formatter) as log_handler:
-            yield  # run test
+        with closing(py.io.TextIO()) as stream:
+            with catching_logs(logging.StreamHandler(stream),
+                               formatter=self.formatter):
+                yield  # run test
 
             if self.print_logs:
                 # Add a captured log section to the report.
-                log = log_handler.stream.getvalue().strip()
+                log = stream.getvalue().strip()
                 item.add_report_section(when, 'log', log)
 
     @pytest.mark.hookwrapper

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
 import logging
+from fnmatch import fnmatch
 
 import pytest
 
@@ -65,3 +66,21 @@ def test_unicode(caplog):
     assert caplog.records[0].levelname == 'INFO'
     assert caplog.records[0].msg == u('bū')
     assert u('bū') in caplog.text
+
+
+def test_mutable_arg(caplog):
+    mutable = {}
+    logger.info("Mutable dict %r empty", mutable)
+    mutable['foo'] = 'bar'
+    logger.info("Mutable dict %r bar", mutable)
+    mutable['foo'] = 'baz'
+    logger.info("Mutable dict %r baz", mutable)
+
+    assert caplog.record_tuples == [
+        (__name__, logging.INFO, "Mutable dict {} empty"),
+        (__name__, logging.INFO, "Mutable dict {'foo': 'bar'} bar"),
+        (__name__, logging.INFO, "Mutable dict {'foo': 'baz'} baz"),
+    ]
+    assert fnmatch(caplog.text, ("*Mutable dict {} empty\n"
+                                 "*Mutable dict {'foo': 'bar'} bar\n"
+                                 "*Mutable dict {'foo': 'baz'} baz\n"))


### PR DESCRIPTION
Changes affecting users:
- Now `caplog.text` always uses the same formatting, regardless the `--log-format` option. You won't want your tests fail because the user prefers another formatting, after all
- Changing the logging level through `caplog` does not affect captured logs shown in case of a failure (this is still not the case when using `caplog.at_level/set_level(logger=...)` though, but I'm going to address this one too in future)

Note: This contains changes that you might happen to review as part of #7, I [decided](https://github.com/eisensheng/pytest-catchlog/pull/7#issuecomment-144866078) to drop these changes from there eventually.
