### PR TITLE
Live logs (-s / --capture=no)

### DIFF
--- a/pytest_catchlog.py
+++ b/pytest_catchlog.py
@@ -152,7 +152,7 @@ class CatchLogPlugin(object):
             yield
 
 
-class RecordingHandler(logging.Handler):
+class RecordingHandler(logging.Handler, object):  # Python 2.6: new-style class
     """A logging handler that stores log records into a buffer."""
 
     def __init__(self):

--- a/pytest_catchlog.py
+++ b/pytest_catchlog.py
@@ -118,12 +118,13 @@ class CatchLogPlugin(object):
         The formatter can be safely shared across all handlers so
         create a single one for the entire test session here.
         """
+        self.capture_logs = (config.getoption('capture', 'no') != 'no')
         self.print_logs = config.getoption('log_print')
         self.formatter = logging.Formatter(
                 get_option_ini(config, 'log_format'),
                 get_option_ini(config, 'log_date_format'))
 
-        handler = logging.StreamHandler()
+        handler = logging.StreamHandler()  # streams to stderr by default
         handler.setFormatter(self.formatter)
 
         self.handler = handler
@@ -137,6 +138,9 @@ class CatchLogPlugin(object):
     @contextmanager
     def _runtest_for(self, item, when):
         """Implements the internals of pytest_runtest_xxx() hook."""
+        if not self.capture_logs:
+            yield
+            return
         with closing(py.io.TextIO()) as stream:
             orig_stream = self.handler.stream
             self.handler.stream = stream

--- a/test_pytest_catchlog.py
+++ b/test_pytest_catchlog.py
@@ -100,17 +100,13 @@ def test_change_level(testdir):
             log.warning('logger WARNING level')
             log.critical('logger CRITICAL level')
 
-            assert False
+            assert 'DEBUG' not in caplog.text
+            assert 'INFO' in caplog.text
+            assert 'WARNING' not in caplog.text
+            assert 'CRITICAL' in caplog.text
         ''')
     result = testdir.runpytest()
-    assert result.ret == 1
-    result.stdout.fnmatch_lines(['*- Captured *log call -*',
-                                 '*handler INFO level*',
-                                 '*logger CRITICAL level*'])
-    py.test.raises(Exception, result.stdout.fnmatch_lines,
-                   ['*- Captured *log call -*', '*handler DEBUG level*'])
-    py.test.raises(Exception, result.stdout.fnmatch_lines,
-                   ['*- Captured *log call -*', '*logger WARNING level*'])
+    assert result.ret == 0
 
 
 @py.test.mark.skipif('sys.version_info < (2,5)')
@@ -131,17 +127,13 @@ def test_with_statement(testdir):
                     log.warning('logger WARNING level')
                     log.critical('logger CRITICAL level')
 
-            assert False
+            assert 'DEBUG' not in caplog.text
+            assert 'INFO' in caplog.text
+            assert 'WARNING' not in caplog.text
+            assert 'CRITICAL' in caplog.text
         ''')
     result = testdir.runpytest()
-    assert result.ret == 1
-    result.stdout.fnmatch_lines(['*- Captured *log call -*',
-                                 '*handler INFO level*',
-                                 '*logger CRITICAL level*'])
-    py.test.raises(Exception, result.stdout.fnmatch_lines,
-                   ['*- Captured *log call -*', '*handler DEBUG level*'])
-    py.test.raises(Exception, result.stdout.fnmatch_lines,
-                   ['*- Captured *log call -*', '*logger WARNING level*'])
+    assert result.ret == 0
 
 
 def test_log_access(testdir):

--- a/test_pytest_catchlog.py
+++ b/test_pytest_catchlog.py
@@ -223,6 +223,22 @@ def test_compat_properties(testdir):
     ''')
 
 
+def test_live_logs(testdir):
+    testdir.makepyfile('''
+        import sys
+        import logging
+
+        logger = logging.getLogger()
+
+        def test_foo(caplog):
+            logger.warning("I'm logging, I'm alive!")
+            sys.stderr.write('text going to stderr')
+        ''')
+    result = testdir.runpytest('-s')
+    result.stderr.fnmatch_lines(["*WARNING*I'm logging, I'm alive!*",
+                                 'text going to stderr'])
+
+
 def test_disable_log_capturing(testdir):
     testdir.makepyfile('''
         import sys


### PR DESCRIPTION
Partially resolves #14 ("Integrate with --capture and -v options of pytest"), in a slightly more natural and efficient way than proposed in #20 ("Move pytest-logging functionality to pytest-catchlog.")

Note: this includes changes proposed in PR #24, **DO NOT MERGE** until #24 is accepted. Also this lacks a proper description in the README.
### TODO
- [ ] README
- [ ] `record.message` not initialized, add tests
