### PR TITLE
Update dependencies in tox.ini.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py{26,27,32,33,34,35}, pypy{,3}
 
 [testenv]
 deps =
-    py==1.4.28
-    pytest==2.7.1
+    py==1.4.30
+    pytest==2.8.3
 commands =
     py.test {posargs:test_pytest_catchlog.py}


### PR DESCRIPTION
The listed pytest version doesn't work with Python 3.5.
