### PR TITLE
tox: deploy plugin before running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ deps =
     py==1.4.30
     pytest==2.8.3
 commands =
-    py.test {posargs:test_pytest_catchlog.py}
+    {envpython} -m py.test {posargs:test_pytest_catchlog.py}


### PR DESCRIPTION
execution of tests fail when you run them under tox.
pytest can not find catchlog plugin.
this patch adds line which installs this plugin into virtenv
and make the plugin visible for pytest.
