### PR TITLE
Add option to set default log-level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,16 @@ of any logger can be changed instead with::
         with caplog.at_level(logging.CRITICAL, logger='root.baz'):
             pass
 
+In aditional you can set default level which will be captured for whole
+test session, by default it is NOTSET. In order to set level you can use CLI::
+
+    py.test --log-capture-level INFO
+
+Or in your ``pytest.cfg``::
+
+    [pytest]
+    log_capture_level = INFO
+
 Lastly all the logs sent to the logger during the test run are made
 available on the funcarg in the form of both the LogRecord instances
 and the final log text.  This is useful for when you want to assert on

--- a/pytest_catchlog.py
+++ b/pytest_catchlog.py
@@ -101,6 +101,13 @@ def pytest_addoption(parser):
                    '--log-date-format',
                    dest='log_date_format', default=None,
                    help='log date format as used by the logging module.')
+    add_option_ini(parser,
+                   '--log-capture-level',
+                   dest='log_capture_level',
+                   choices=('NOTSET', 'DEBUG', 'INFO', 'WARN', 'ERROR',
+                            'CRITICAL'),
+                   default='NOTSET',
+                   help='Set default level of logs to be captured. (NOTSET)')
 
 
 def pytest_configure(config):
@@ -130,12 +137,15 @@ class CatchLogPlugin(object):
         self.formatter = logging.Formatter(
                 get_option_ini(config, 'log_format'),
                 get_option_ini(config, 'log_date_format'))
+        self.default_level = getattr(
+            logging, get_option_ini(config, 'log_capture_level'))
 
     @contextmanager
     def _runtest_for(self, item, when):
         """Implements the internals of pytest_runtest_xxx() hook."""
         with catching_logs(LogCaptureHandler(),
-                           formatter=self.formatter) as log_handler:
+                           formatter=self.formatter,
+                           level=self.default_level) as log_handler:
             item.catch_log_handler = log_handler
             try:
                 yield  # run test

--- a/test_pytest_catchlog.py
+++ b/test_pytest_catchlog.py
@@ -326,3 +326,24 @@ def test_disable_log_capturing_ini(testdir):
                                  'text going to stderr'])
     py.test.raises(Exception, result.stdout.fnmatch_lines,
                    ['*- Captured *log call -*'])
+
+def test_default_capture_level(testdir):
+    testdir.makeini('''
+        [pytest]
+        log_capture_level=INFO
+        ''')
+    testdir.makepyfile('''
+        import logging
+
+        def test_foo():
+            logging.getLogger().debug('NOT THERE')
+            logging.getLogger().info("INCLUDED")
+            assert False
+        ''')
+    result = testdir.runpytest()
+    assert result.ret == 1
+    result.stdout.fnmatch_lines(['*- Captured *log call -*',
+                                 '*INCLUDED*'])
+    py.test.raises(Exception,
+                   result.stdout.fnmatch_lines,
+                   ['*- Captured *log call -*', '*NOT THERE*'])


### PR DESCRIPTION
It could be useful when you want to reduce logs to be captured for whole pytest session.
