### PR TITLE
Performance test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 
 # Unit test / coverage reports
 htmlcov/
+.benchmarks/
 .tox/
 .coverage
 .cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,20 @@ python:
   - "3.5"
   - "pypy"
   - "pypy3"
+before_install: |
+  pip install tox "virtualenv<14.0.0" # recent versions don't run on Python 3.2
+  if [ ! -v TOXENV ]
+  then
+    __py_ver=$TRAVIS_PYTHON_VERSION
+    export TOXENV=${__py_ver/[0-9].[0-9]/py${__py_ver/.}}
+  fi
+  function announce()
+    { echo -e "$ANSI_GREEN$@${ANSI_RESET}"; }
+  function tox()
+    { announce "Running tox in TOXENV=$TOXENV"; env tox "$@"; }
 
-install:
-  - pip install -e .
-script:
-  - py.test
+install: tox --notest
+script: tox
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,18 @@ python:
   - "3.5"
   - "pypy"
   - "pypy3"
+matrix:
+  include:
+    - python: "2.7"
+      env: TOXENV=perf
+
 before_install: |
   pip install tox "virtualenv<14.0.0" # recent versions don't run on Python 3.2
   if [ ! -v TOXENV ]
   then
     __py_ver=$TRAVIS_PYTHON_VERSION
-    export TOXENV=${__py_ver/[0-9].[0-9]/py${__py_ver/.}}
+    __tox_dfl=${__py_ver/[0-9].[0-9]/py${__py_ver/.}}
+    export TOXENV=${TOXENV:-$__tox_dfl}
   fi
   function announce()
     { echo -e "$ANSI_GREEN$@${ANSI_RESET}"; }

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ before_install: |
 install: tox --notest
 script: tox
 
+before_cache:
+  - rm -rf $HOME/.cache/pip/log
 cache:
   directories:
-    - $HOME/.cache/pip/http
+    - $HOME/.cache/pip
 
 deploy:
   provider: pypi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,16 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
 import pytest
 
+
 pytest_plugins = 'pytester'
+
+
+def pytest_addoption(parser):
+    parser.addoption('--run-perf',
+        action='store', dest='run_perf',
+        choices=['yes', 'no', 'only', 'check'],
+        nargs='?', default='check', const='yes',
+        help='Run performance tests (can be slow)',
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,3 +14,20 @@ def pytest_addoption(parser):
         nargs='?', default='check', const='yes',
         help='Run performance tests (can be slow)',
     )
+
+    parser.addoption('--perf-graph',
+        action='store', dest='perf_graph_name',
+        nargs='?', default=None, const='graph.svg',
+        help='Plot a graph using data found in --benchmark-storage',
+    )
+    parser.addoption('--perf-expr',
+        action='store', dest='perf_expr_primary',
+        default='log_emit',
+        help='Benchmark (or expression combining benchmarks) to plot',
+    )
+    parser.addoption('--perf-expr-secondary',
+        action='store', dest='perf_expr_secondary',
+        default='caplog - stub',
+        help=('Benchmark (or expression combining benchmarks) to plot '
+              'as a secondary line'),
+    )

--- a/tests/perf/bench/conftest.py
+++ b/tests/perf/bench/conftest.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+
+class CatchLogStub(object):
+    """Provides a no-op 'caplog' fixture fallback."""
+
+    @pytest.yield_fixture
+    def caplog(self):
+        yield
+
+
+@pytest.mark.trylast
+def pytest_configure(config):
+    if not pytest.config.pluginmanager.hasplugin('pytest_catchlog'):
+        config.pluginmanager.register(CatchLogStub(), 'caplog_stub')

--- a/tests/perf/bench/pytest.ini
+++ b/tests/perf/bench/pytest.ini
@@ -1,0 +1,11 @@
+# This file prevents upward conftests from being loaded.
+#
+# You can run performance test bench manually as follows:
+#
+#   $ cd tests/perf/bench && py.test
+#
+# OR
+#
+#   $ py.test tests/perf/bench --confcutdir=tests/perf/bench
+#
+[pytest]

--- a/tests/perf/bench/test_log.py
+++ b/tests/perf/bench/test_log.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import, division, print_function
+
+import logging
+
+
+logger = logging.getLogger('pytest_catchlog.test.perf')
+
+
+def test_log_emit(benchmark):
+    benchmark(logger.info, 'Testing %s performance: %s',
+              'catchlog', 'emit a single log record')

--- a/tests/perf/bench/test_runtest_hook.py
+++ b/tests/perf/bench/test_runtest_hook.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import, division, print_function
+
+import logging
+
+import pytest
+
+
+logger = logging.getLogger('pytest_catchlog.test.perf')
+
+
+@pytest.fixture(autouse=True)
+def bench_runtest(request, benchmark):
+    # Using benchmark.weave to patch a runtest hook doesn't seem to work with
+    # pytest 2.8.3; for some reason hook gets called more than once, before
+    # running benchmark cleanup finalizer, resulting in the
+    # "FixtureAlreadyUsed: Fixture can only be used once" error.
+    #
+    # Use plain old monkey patching instead.
+    ihook = request.node.ihook
+    saved_hook = ihook.pytest_runtest_call
+
+    def patched_hook(*args, **kwargs):
+        ihook.pytest_runtest_call = saved_hook  # restore early
+        return benchmark(saved_hook, *args, **kwargs)
+
+    ihook.pytest_runtest_call = patched_hook
+    benchmark.group = 'runtest'
+
+
+@pytest.yield_fixture  # because 'caplog' is also a yield_fixture
+def stub():
+    """No-op stub used in place of 'caplog'.
+
+    Helps to measure the inevitable overhead of the pytest fixture injector to
+    let us exclude it later on.
+    """
+    yield
+
+
+def test_fixture_stub(stub):
+    logger.info('Testing %r hook performance: %s',
+                'catchlog', 'pure runtest hookwrapper overhead')
+
+
+def test_caplog_fixture(caplog):
+    logger.info('Testing %r hook performance: %s',
+                'catchlog', 'hookwrapper + caplog fixture overhead')

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -1,0 +1,89 @@
+from __future__ import absolute_import, division, print_function
+
+import os.path
+
+import py
+import pytest
+
+
+BENCH_DIR = py.path.local(__file__).dirpath('bench')
+
+
+mode_args_map = {
+    'default':   [],
+    'noplugin':  ['-pno:pytest_catchlog'],
+    'noprint':   ['--no-print-logs'],
+    'nocapture': ['-s'],
+}
+
+
+def path_in_dir(path, dir=py.path.local(__file__).dirpath()):
+    return (dir.common(path) == dir)
+
+
+def pytest_ignore_collect(path):
+    if path_in_dir(path, BENCH_DIR):
+        # Tests from that directory never run through test discovery.
+        #
+        # Instead, they run either with the BENCH_DIR specified explicitly
+        # both as a target and a 'confcutdir' or when the BENCH_DIR itself
+        # is a 'rootdir' (CWD). In any case this conftest is not processed
+        # at all, and this hook doesn't run when running tests from the
+        # BENCH_DIR.
+        return True
+
+
+def pytest_itemcollected(item):
+    """This is only called for local tests (under tests/perf_runner/)."""
+    if path_in_dir(item.fspath):
+        item.add_marker('_perf_test')
+
+
+def pytest_collection_modifyitems(session, config, items):
+    """This is called after collection (of all tests) has been performed."""
+    run_perf = config.getoption('run_perf')
+    if run_perf in ('yes', 'check'):
+        return
+    perf_only = (run_perf == 'only')
+
+    items[:] = [item
+                for item in items
+                if bool(item.get_marker('_perf_test')) == perf_only]
+
+
+def pytest_terminal_summary(terminalreporter):
+    """Add additional section in terminal summary reporting."""
+    config = terminalreporter.config
+
+    if config.getoption('run_perf') in ('yes', 'only'):
+        passed = terminalreporter.stats.get('passed', [])
+        for rep in passed:
+            if '_perf_test' not in rep.keywords:
+                continue
+
+            out = '\n'.join(s for _, s in rep.get_sections('Captured stdout'))
+            if out:
+                fspath, lineno, name = rep.location
+                terminalreporter.write_sep("-", 'Report from {0}'.format(name))
+                terminalreporter.write(out)
+
+
+@pytest.fixture(params=sorted(mode_args_map))
+def mode(request):
+    return request.param
+
+
+@pytest.fixture
+def mode_args(mode):
+    return mode_args_map[mode]
+
+
+@pytest.fixture
+def storage_dir(pytestconfig, mode):
+    storage = pytestconfig.getoption('--benchmark-storage')
+    return os.path.join(storage, mode)
+
+
+@pytest.fixture
+def bench_dir():
+    return BENCH_DIR

--- a/tests/perf/conftest.py
+++ b/tests/perf/conftest.py
@@ -1,9 +1,16 @@
 from __future__ import absolute_import, division, print_function
 
 import os.path
+try:
+    from builtins import __dict__ as builtins
+except ImportError:  # Python 2
+    from __builtin__ import __dict__ as builtins
 
 import py
 import pytest
+
+from .data import gen_dict, load_benchmarks
+from .plot import make_plot
 
 
 BENCH_DIR = py.path.local(__file__).dirpath('bench')
@@ -15,6 +22,17 @@ mode_args_map = {
     'noprint':   ['--no-print-logs'],
     'nocapture': ['-s'],
 }
+
+
+def pytest_configure(config):
+    if (config.getoption('run_perf') in ('yes', 'only') and
+        config.getoption('perf_graph_name')):
+
+        expr = config.getoption('perf_expr_primary')
+        expr2 = config.getoption('perf_expr_secondary')
+        if not (expr or expr2):
+            raise pytest.UsageError('perf-graph: Nothing to plot, '
+                                    'see --perf-expr')
 
 
 def path_in_dir(path, dir=py.path.local(__file__).dirpath()):
@@ -66,6 +84,95 @@ def pytest_terminal_summary(terminalreporter):
                 fspath, lineno, name = rep.location
                 terminalreporter.write_sep("-", 'Report from {0}'.format(name))
                 terminalreporter.write(out)
+
+    handle_perf_graph(config, terminalreporter)
+
+
+def handle_perf_graph(config, terminalreporter):
+    output_file = config.getoption('perf_graph_name')
+    if not output_file:
+        return
+
+    bench_storage = config.getoption('--benchmark-storage')
+    output_file = os.path.join(bench_storage, output_file)
+
+    trial_names, benchmarks = load_benchmarks(bench_storage,
+                                              modes=sorted(mode_args_map))
+    if not trial_names:
+        terminalreporter.write_line(
+            'perf-graph: No benchmarks found in {0}'.format(bench_storage),
+            yellow=True, bold=True)
+        return
+
+    expr = config.getoption('perf_expr_primary')
+    expr2 = config.getoption('perf_expr_secondary')
+
+    history = eval_benchmark_expr(expr, benchmarks)
+    history2 = eval_benchmark_expr(expr2, benchmarks)
+
+    plot = make_plot(
+        trial_names=trial_names,
+        history=history,
+        history2=history2,
+        expr=expr,
+        expr2=expr2,
+    )
+    plot.render_to_file(output_file)
+
+    terminalreporter.write_line(
+        'perf-graph: Saved graph into {0}'.format(output_file),
+        green=True, bold=True)
+
+
+@gen_dict
+def eval_benchmark_expr(expr, benchenvs, **kwargs):
+    for mode, envlist in benchenvs.items():
+        yield mode, [BenchmarkEnv(benchenv, **kwargs).evaluate(expr)
+                     for benchenv in envlist]
+
+
+class BenchmarkEnv(dict):
+    """Holds results of benchmark tests.
+
+    Allows unambiguous access through a key substring: e.g. just 'foo' for
+    'test_foo_stuff' (but at the same time there must not be 'test_some_food').
+    """
+    __slots__ = ()
+
+    class UndefinedValue(ValueError):
+        pass
+
+    def __missing__(self, lookup):
+        if lookup in builtins:
+            raise KeyError  # to make builtins handled as usual
+
+        found = None
+        for key in self:
+            if lookup in key:  # substring match
+                if found is not None:
+                    raise pytest.UsageError('Ambiguous benchmark ID: '
+                                            'multiple tests match {lookup!r} '
+                                            '(at least {found!r} and {key!r})'
+                                            .format(**locals()))
+                found = key
+        if found is None:
+            raise pytest.UsageError('Unknown benchmark ID: '
+                                    'no test matches {lookup!r}: {self}'
+                                    .format(**locals()))
+        ret = self[found]
+        if ret is None:
+            # If an expression involves None (i.e. undefined),
+            # the result must be also None.
+            raise self.UndefinedValue('Missing proper benchmark value')
+
+        return ret
+
+    def evaluate(self, expr):
+        """Evaluate an expression using this environment as globals."""
+        try:
+            return eval(expr.strip() or 'None', {}, self)
+        except self.UndefinedValue:
+            return None
 
 
 @pytest.fixture(params=sorted(mode_args_map))

--- a/tests/perf/data.py
+++ b/tests/perf/data.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import, division, print_function
+
+import io
+import json
+import os.path
+from functools import wraps
+from glob import glob
+from itertools import chain
+
+
+def gen_dict(func):
+    @wraps(func)
+    def decorated(*args, **kwargs):
+        return dict(func(*args, **kwargs))
+    return decorated
+
+
+@gen_dict  # {'mode': {'NNNN': benchmark, ...}}
+def load_raw_benchmarks(storage, modes):
+    for mode in sorted(modes):
+        trialmap = {}
+
+        for bench_file in glob(os.path.join(storage, mode,
+                                            '[0-9][0-9][0-9][0-9]_*.json')):
+            trial_name = os.path.split(bench_file)[1].partition('_')[0]  # NNNN
+            with io.open(bench_file, 'rU') as fh:
+                data = json.load(fh)
+            trialmap[trial_name] = data
+
+        yield mode, trialmap
+
+
+def all_trial_names(raw_benchmarks):
+    return sorted(set(chain.from_iterable(raw_benchmarks.values())))
+
+
+@gen_dict  # {'mode': [{'test': min}...]}
+def prepare_benchmarks(raw_benchmarks, trial_names):
+    for mode, trialmap in raw_benchmarks.items():
+        envlist = []
+
+        for trial_name in trial_names:
+            trial = trialmap.get(trial_name, {}).get('benchmarks', [])
+
+            benchenv = dict((bench['fullname'], bench['stats'].get('min'))
+                            for bench in trial)
+            envlist.append(benchenv)
+
+        yield mode, envlist
+
+
+def load_benchmarks(bench_storage, modes):
+    raw_benchmarks = load_raw_benchmarks(bench_storage, modes)
+    trial_names = all_trial_names(raw_benchmarks)
+    benchmarks = prepare_benchmarks(raw_benchmarks, trial_names)
+
+    return trial_names, benchmarks

--- a/tests/perf/plot.py
+++ b/tests/perf/plot.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import, division, print_function
+
+import pygal
+from pygal.style import DefaultStyle
+
+try:
+    import pygaljs
+except ImportError:
+    opts = {}
+else:
+    opts = {"js": [pygaljs.uri("2.0.x", "pygal-tooltips.js")]}
+
+opts["css"] = [
+    "file://style.css",
+    "file://graph.css",
+    """inline:
+        .axis.x text {
+            text-anchor: middle !important;
+        }
+        .tooltip .value {
+            font-size: 1em !important;
+        }
+    """
+]
+
+
+def make_plot(trial_names, history, history2, expr, expr2):
+    style = DefaultStyle(colors=[
+            '#ED6C1D',  # 3
+            '#EDC51E',  # 4
+            '#BCED1E',  # 5
+            '#63ED1F',  # 6
+            '#1FED34',  # 7
+            '#ED1D27',  # 2
+        ][:len(history)] + [
+            '#A71DED',  # -3
+            '#4F1EED',  # -4
+            '#1E45ED',  # -5
+            '#1F9EED',  # -6
+            '#1FEDE4',  # -7
+            '#ED1DDA',  # -2
+        ][:len(history2)]
+    )
+
+    plot = pygal.Line(
+        title="Speed in seconds",
+        x_title="Trial",
+        x_labels=trial_names,
+        include_x_axis=True,
+        human_readable=True,
+        truncate_legend=8,
+        style=style,
+        stroke_style={'width': 2, 'dasharray': '20, 4'},
+        **opts
+    )
+
+    format_name = '{0} ({1})'.format
+
+    for mode in sorted(history):
+        serie = history[mode]
+        plot.add(format_name(mode, expr), serie,
+                 stroke_style={'dasharray': 'none'})
+
+    for mode in sorted(history2):
+        serie = history2[mode]
+        plot.add(format_name(mode, expr2), serie, secondary=True)
+
+    return plot

--- a/tests/perf/test_perf_run.py
+++ b/tests/perf/test_perf_run.py
@@ -1,0 +1,82 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+import os.path
+import sys
+import subprocess
+
+import pytest
+
+
+PYTEST_PATH = (os.path.abspath(pytest.__file__.rstrip("oc"))
+               .replace("$py.class", ".py"))
+
+
+@pytest.fixture
+def popen(request):
+    env = os.environ.copy()
+    cwd = os.getcwd()
+    pythonpath = [cwd]
+    if env.get('PYTHONPATH'):
+        pythonpath.append(env['PYTHONPATH'])
+    env['PYTHONPATH'] = os.pathsep.join(pythonpath)
+
+    def popen_wait(*args, **kwargs):
+        __tracebackhide__ = True
+
+        args = [str(arg) for arg in args]
+        kwargs['env'] = dict(env, **kwargs.get('env', {}))
+
+        print('Running', ' '.join(args))
+        ret = subprocess.Popen(args, **kwargs).wait()
+        assert ret == 0
+
+    return popen_wait
+
+
+@pytest.fixture
+def color(pytestconfig):
+    reporter = pytestconfig.pluginmanager.getplugin('terminalreporter')
+    try:
+        return 'yes' if reporter.writer.hasmarkup else 'no'
+    except AttributeError:
+        return pytestconfig.option.color
+
+
+@pytest.fixture
+def verbosity(pytestconfig):
+    v = pytestconfig.option.verbose or -1
+    return ('v' if v > 0 else 'q') * abs(v)
+
+@pytest.fixture
+def base_args(bench_dir, verbosity, color):
+    return [
+        bench_dir,
+        '--confcutdir={0}'.format(bench_dir),
+        '-x',
+        '-{0}'.format(verbosity),
+        '-rw',
+        '--color={0}'.format(color),
+    ]
+
+
+@pytest.fixture
+def bench_args(pytestconfig, storage_dir):
+    if pytestconfig.getoption('run_perf') != 'check':
+        return [
+            '--benchmark-only',
+            '--benchmark-disable-gc',
+            '--benchmark-autosave',
+            '--benchmark-storage={0}'.format(storage_dir),
+        ]
+    else:
+        return ['--benchmark-disable']
+
+
+@pytest.fixture
+def perf_args(base_args, mode_args, bench_args):
+    return base_args + mode_args + bench_args
+
+
+def test_perf_run(popen, perf_args):
+    popen(sys.executable, PYTEST_PATH, *perf_args)

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ deps =
     pygal==2.1.1
     pygaljs==1.0.1
 commands =
-    {envpython} -m py.test {posargs:tests}
+    {envpython} -m pytest {posargs:tests}
 
 [testenv:perf]
 basepython = python2.7
 commands =
-    {envpython} -m py.test --run-perf=only {posargs:tests}
+    {envpython} -m pytest --run-perf=only {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,6 @@ envlist = py{26,27,32,33,34,35}, pypy{,3}
 deps =
     py==1.4.30
     pytest==2.8.3
+    pytest-benchmark[aspect]==3.0.0
 commands =
     {envpython} -m py.test {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,32,33,34,35}, pypy{,3}
+envlist = py{26,27,32,33,34,35}, pypy{,3}, perf
 
 [testenv]
 deps =
@@ -8,3 +8,8 @@ deps =
     pytest-benchmark[aspect]==3.0.0
 commands =
     {envpython} -m py.test {posargs:tests}
+
+[testenv:perf]
+basepython = python2.7
+commands =
+    {envpython} -m py.test --run-perf=only {posargs:tests}

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ deps =
     py==1.4.30
     pytest==2.8.3
     pytest-benchmark[aspect]==3.0.0
+    pygal==2.1.1
+    pygaljs==1.0.1
 commands =
     {envpython} -m py.test {posargs:tests}
 


### PR DESCRIPTION
Measure an overhead of having the pytest-catchlog plugin activated, namely:
- `(caplog - stub)` the cost of requesting a `caplog` fixture (minus an overhead incurred by pytest to prepare an empty fixture)
- `log_emit` the cost of emitting a log message

These costs are evaluated in 4 different scenarios:
- default
- noplugin - when catchlog is not activated, i.e. running with `-pno:pytest_catchlog`
- noprint - when logs are not reported, i.e. running with `--no-print-logs`
- nocapture - when running with `-s`

Also add a cmdline option to plot multiple measurements for comparison. For example, to estimate how each commit in a branch affects performance and at the same time ensure branch bisectability before pushing it to submit a PR:

``` console
$ rm -rf ./.benchmarks  # clean up old measurements, if any
$ git rebase upstream/develop -i --exec 'tox -eperf'  # save and close an editor
...  # wait until done
$ tox -eperf -- --collect-only --perf-graph
```

A graph.svg file will be saved somewhere like ./.benchmarks/Linux-CPython-2.7-64bit/

@The-Compiler @eisensheng I'd like this to be merged ASAP at least since it doesn't affect any logic besides tests. Your feedback will be appreciated!
