### PR TITLE
Add a clear method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,13 @@ given severity and message::
             ('root', logging.INFO, 'boo arg'),
         ]
 
+You can call ``caplog.clear()`` to reset the captured log records in a test::
+
+    def test_something_with_clearing_records(caplog):
+        some_method_that_creates_log_records()
+        caplog.clear()
+        your_test_method()
+        assert ['Foo'] == [rec.message for rec in caplog.records]
 
 Live Logs
 ~~~~~~~~~

--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -42,6 +42,10 @@ class LogCaptureFixture(object):
         """
         return [(r.name, r.levelno, r.getMessage()) for r in self.records]
 
+    def clear(self):
+        """Reset the list of log records."""
+        self.handler.records = []
+
     def set_level(self, level, logger=None):
         """Sets the level for capturing of logs.
 
@@ -88,8 +92,11 @@ class CallablePropertyMixin(object):
         return make_property(getter)
 
     def __call__(self):
+        new = "'caplog.{0}' property".format(self._prop_name)
+        if self._prop_name == 'records':
+            new += ' (or caplog.clear())'
         self._warn_compat(old="'caplog.{0}()' syntax".format(self._prop_name),
-                          new="'caplog.{0}' property".format(self._prop_name))
+                          new=new)
         return self._naked_value  # to let legacy clients modify the object
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py{26,27,32,33,34,35}, pypy{,3}, perf
 [testenv]
 deps =
     py==1.4.30
-    pytest==2.8.3
+    pytest==3.0.1
     pytest-benchmark[aspect]==3.0.0
     pygal==2.1.1
     pygaljs==1.0.1


### PR DESCRIPTION
This is required since `del caplog.records()[:]` will issue a
deprecation warning, because `records` became a property.

Fixes https://github.com/eisensheng/pytest-catchlog/issues/45.
