### PR TITLE
filter_record_tuples() implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ python:
   - "3.4"
   - "3.5"
   - "pypy"
-  - "pypy3"
+# Note: Disabled pypy3 due to currently being broken on travis-ci.
+# See: https://github.com/travis-ci/travis-ci/issues/6277#issuecomment-265128578
+#  - "pypy3"
 matrix:
   include:
     - python: "2.7"

--- a/README.rst
+++ b/README.rst
@@ -147,8 +147,8 @@ given severity and message::
             ('root', logging.INFO, 'boo arg'),
         ]
 
-To aid in common test scenarios, caplog exposes logging levels under 
-``caplog.levels`` to prevent the need to import the ``logging`` module in tests.
+To aid in common test scenarios, caplog exposes logging levels to prevent the
+need to import the ``logging`` module in tests.
 
 Furthermore ``filter_records`` or ``filter_record_tuples`` can be used to easily filter
 log messages of a particular logger. This is especially useful for testing composite systems where
@@ -159,8 +159,8 @@ several components have loggers::
 
         assert not any([r.levelno >= caplog.ERROR for r in caplog.filter_records('components.a')])
 
-        assert caplog.filter_record_tuples('components.a', caplog.levels.INFO, 'foo')
-        assert caplog.filter_record_tuples('components.b', caplog.levels.INFO, re.compile(r'foo\s.+'))
+        assert caplog.filter_record_tuples('components.a', caplog.INFO, 'foo')
+        assert caplog.filter_record_tuples('components.b', caplog.INFO, re.compile(r'foo\s.+'))
 
 You can call ``caplog.clear()`` to reset the captured log records in a test::
 

--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,18 @@ given severity and message::
             ('root', logging.INFO, 'boo arg'),
         ]
 
+To aid in common test scenarios, caplog exposes logging levels under 
+``caplog.levels`` to prevent the need to import the ``logging`` module in tests.
+Furthermore ``filter_record_tuples`` can be used to easily filter log messages of
+a particular logger. This ise specially useful for testing composite systems where 
+several components have loggers::
+
+    def test_foo(caplog):
+        func_under_test()
+
+        assert caplog.filter_record_tuples('components.a', caplog.levels.INFO, 'foo')
+        assert caplog.filter_record_tuples('components.b', caplog.levels.INFO, re.compile(r'foo\s.+'))
+
 You can call ``caplog.clear()`` to reset the captured log records in a test::
 
     def test_something_with_clearing_records(caplog):

--- a/README.rst
+++ b/README.rst
@@ -149,12 +149,15 @@ given severity and message::
 
 To aid in common test scenarios, caplog exposes logging levels under 
 ``caplog.levels`` to prevent the need to import the ``logging`` module in tests.
-Furthermore ``filter_record_tuples`` can be used to easily filter log messages of
-a particular logger. This ise specially useful for testing composite systems where 
+
+Furthermore ``filter_records`` or ``filter_record_tuples`` can be used to easily filter
+log messages of a particular logger. This is especially useful for testing composite systems where
 several components have loggers::
 
     def test_foo(caplog):
         func_under_test()
+
+        assert not any([r.levelno >= caplog.ERROR for r in caplog.filter_records('components.a')])
 
         assert caplog.filter_record_tuples('components.a', caplog.levels.INFO, 'foo')
         assert caplog.filter_record_tuples('components.b', caplog.levels.INFO, re.compile(r'foo\s.+'))

--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -16,6 +16,9 @@ class LogCaptureFixture(object):
     def __init__(self, item):
         """Creates a new funcarg."""
         self._item = item
+        # set logging levels to facilitate use without needing to import logging
+        for level in ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET']:
+            setattr(self, level, getattr(logging, level))
 
     @property
     def handler(self):

--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -21,7 +21,7 @@ class LogCaptureFixture(object):
         if name.isupper() and name.isalpha():
             # lookup names matching level pattern in logging module
             return getattr(logging, name)
-        raise AttributeError("'{}' object has no attribute ''".format(
+        raise AttributeError("'{}' object has no attribute '{}'".format(
             type(self).__name__,
             name
         ))

--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -34,6 +34,9 @@ class LogCaptureFixture(object):
         """Returns the list of log records."""
         return self.handler.records
 
+    def filter_records(self,  name=None, level=None, message=None):
+        return self._filter_records(name, level, message)
+
     @property
     def record_tuples(self):
         """Returns a list of a striped down version of log records intended
@@ -82,6 +85,22 @@ class LogCaptureFixture(object):
 
         obj = logger and logging.getLogger(logger) or self.handler
         return logging_at_level(level, obj)
+
+    def _filter_records(self, name, level, message):
+        def _filter(r):
+            if name and not r.name == name:
+                return False
+            if level and not r.levelno == level:
+                return False
+            if message:
+                try:
+                    if not bool(message.search(r.getMessage())):
+                        return False
+                except AttributeError:
+                    if message not in r.getMessage():
+                        return False
+            return True
+        return list(filter(_filter, self.handler.records))
 
 
 class CallablePropertyMixin(object):

--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -21,7 +21,10 @@ class LogCaptureFixture(object):
         if name.isupper() and name.isalpha():
             # lookup names matching level pattern in logging module
             return getattr(logging, name)
-        return getattr(self, name)
+        raise AttributeError("'{}' object has no attribute ''".format(
+            type(self).__name__,
+            name
+        ))
 
     @property
     def handler(self):

--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -35,6 +35,14 @@ class LogCaptureFixture(object):
         return self.handler.records
 
     def filter_records(self,  name=None, level=None, message=None):
+        """Returns a filtered list of records
+
+        Args:
+            name (str, optional): Exact match of the logger name
+            level (int, optional): The log level of the record
+            message (str|regex, optional): Message part that should be in the record text or
+                the regular expression the record text should match
+        """
         return self._filter_records(name, level, message)
 
     @property
@@ -46,7 +54,7 @@ class LogCaptureFixture(object):
 
             (logger_name, log_level, message)
         """
-        return [(r.name, r.levelno, r.getMessage()) for r in self.records]
+        return self._make_tuples(self.records)
 
     def filter_record_tuples(self, name=None, level=None, message=None):
         """Returns a filtered list of record tuples for use in asserts
@@ -57,8 +65,7 @@ class LogCaptureFixture(object):
             message (str|regex, optional): Message part that should be in the record text or 
                 the regular expression the record text should match
         """
-        # @TODO implement
-        return self.record_tuples
+        return self._make_tuples(self._filter_records(name, level, message))
 
     def clear(self):
         """Reset the list of log records."""
@@ -87,6 +94,7 @@ class LogCaptureFixture(object):
         return logging_at_level(level, obj)
 
     def _filter_records(self, name, level, message):
+        """Filter records on given args"""
         def _filter(r):
             if name and not r.name == name:
                 return False
@@ -101,6 +109,10 @@ class LogCaptureFixture(object):
                         return False
             return True
         return list(filter(_filter, self.handler.records))
+
+    def _make_tuples(self, records):
+        """Convert records to tuples"""
+        return [(r.name, r.levelno, r.getMessage()) for r in records]
 
 
 class CallablePropertyMixin(object):

--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -21,7 +21,7 @@ class LogCaptureFixture(object):
         if name.isupper() and name.isalpha():
             # lookup names matching level pattern in logging module
             return getattr(logging, name)
-        raise AttributeError("'{}' object has no attribute '{}'".format(
+        raise AttributeError("'{0}' object has no attribute '{1}'".format(
             type(self).__name__,
             name
         ))

--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -16,9 +16,12 @@ class LogCaptureFixture(object):
     def __init__(self, item):
         """Creates a new funcarg."""
         self._item = item
-        # set logging levels to facilitate use without needing to import logging
-        for level in ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET']:
-            setattr(self, level, getattr(logging, level))
+
+    def __getattr__(self, name):
+        if name.isupper() and name.isalpha():
+            # lookup names matching level pattern in logging module
+            return getattr(logging, name)
+        return getattr(self, name)
 
     @property
     def handler(self):

--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -42,6 +42,18 @@ class LogCaptureFixture(object):
         """
         return [(r.name, r.levelno, r.getMessage()) for r in self.records]
 
+    def filter_record_tuples(self, name=None, level=None, message=None):
+        """Returns a filtered list of record tuples for use in asserts
+
+        Args:
+            name (str, optional): Exact match of the logger name
+            level (int, optional): The log level of the record
+            message (str|regex, optional): Message part that should be in the record text or 
+                the regular expression the record text should match
+        """
+        # @TODO implement
+        return self.record_tuples
+
     def clear(self):
         """Reset the list of log records."""
         self.handler.records = []

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -96,18 +96,17 @@ def test_filter_record_tuples(caplog, name, level, message, expected):
     'CRITICAL',
     'ERROR',
     'WARNING',
-    'WARN',  # deprecated
     'INFO',
     'DEBUG',
     'NOTSET',
 ])
 def test_levels(caplog, level):
-    assert getattr(caplog.levels, level) == getattr(logging, level)
+    assert getattr(caplog, level) == getattr(logging, level)
 
 
 def test_levels_error(caplog):
     with pytest.raises(AttributeError):
-        getattr(caplog.levels, 'UNKNOWNLEVEL')
+        getattr(caplog, 'UNKNOWNLEVEL')
 
 
 def test_unicode(caplog):

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -78,6 +78,24 @@ def test_filter_record_tuples(caplog, name, level, message, expected):
     assert [f[2].split(' ')[0] for f in filtered] == expected
 
 
+@pytest.mark.parametrize('level', [
+    'CRITICAL',
+    'ERROR',
+    'WARNING',
+    'WARN',  # deprecated
+    'INFO',
+    'DEBUG',
+    'NOTSET',
+])
+def test_levels(caplog, level):
+    assert getattr(caplog.levels, level) == getattr(logging, level)
+
+
+def test_levels_error(caplog):
+    with pytest.raises(AttributeError):
+        getattr(caplog.levels, 'UNKNOWNLEVEL')
+
+
 def test_unicode(caplog):
     logger.info(u('bū'))
     assert caplog.records[0].levelname == 'INFO'

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -16,9 +16,17 @@ filter_params = [
     (__name__, logging.INFO, 'o ar', ['foo']),
     ('other', logging.INFO, 'foo', []),
     (__name__, logging.WARNING, 'foo', []),
+    (__name__, 45, 'foo arg', ['foo']),
     (__name__, logging.INFO, re.compile('o\s'), ['foo']),
     (__name__, logging.INFO, re.compile('foo$'), []),
 ]
+
+
+def do_test_filter_record_logging():
+    """do logging for tests parametrized by filter_params"""
+    logger.info('foo %s', 'arg')
+    logger.info('bar %s', 'arg')
+    logger.log(45, 'foo %s', 'arg')
 
 
 def test_fixture_help(testdir):
@@ -73,8 +81,7 @@ def test_record_tuples(caplog):
 
 @pytest.mark.parametrize('name, level, message, expected', filter_params)
 def test_filter_records(caplog, name, level, message, expected):
-    logger.info('foo %s', 'arg')
-    logger.info('bar %s', 'arg')
+    do_test_filter_record_logging()
 
     filtered = caplog.filter_records(name, level, message)
     filtered_named_args = caplog.filter_records(name=name, level=level, message=message)
@@ -85,8 +92,7 @@ def test_filter_records(caplog, name, level, message, expected):
 
 @pytest.mark.parametrize('name, level, message, expected', filter_params)
 def test_filter_record_tuples(caplog, name, level, message, expected):
-    logger.info('foo %s', 'arg')
-    logger.info('bar %s', 'arg')
+    do_test_filter_record_logging()
 
     filtered = caplog.filter_record_tuples(name, level, message)
     filtered_named_args = caplog.filter_record_tuples(name=name, level=level, message=message)

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import re
 import sys
 import logging
 
@@ -15,6 +16,8 @@ filter_params = [
     (__name__, logging.INFO, 'o ar', ['foo']),
     ('other', logging.INFO, 'foo', []),
     (__name__, logging.WARNING, 'foo', []),
+    (__name__, logging.INFO, re.compile('o\s'), ['foo']),
+    (__name__, logging.INFO, re.compile('foo$'), []),
 ]
 
 
@@ -77,7 +80,7 @@ def test_filter_records(caplog, name, level, message, expected):
     filtered_named_args = caplog.filter_records(name=name, level=level, message=message)
 
     assert filtered == filtered_named_args
-    assert [f.msg.split(' ')[0] for f in filtered] == expected
+    assert [f.getMessage().split(' ')[0] for f in filtered] == expected
 
 
 @pytest.mark.parametrize('name, level, message, expected', filter_params)

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -2,6 +2,7 @@
 import sys
 import logging
 
+import pytest
 
 logger = logging.getLogger(__name__)
 sublogger = logging.getLogger(__name__+'.baz')
@@ -57,6 +58,24 @@ def test_record_tuples(caplog):
     assert caplog.record_tuples == [
         (__name__, logging.INFO, 'boo arg'),
     ]
+
+
+@pytest.mark.parametrize('name, level, message, expected', [
+    (__name__, logging.INFO, None, ['foo', 'bar']),
+    (__name__, logging.INFO, 'foo', ['foo']),
+    (__name__, logging.INFO, 'o ar', ['foo']),
+    ('other', logging.INFO, 'foo', []),
+    (__name__, logging.WARNING, 'foo', []),
+])
+def test_filter_record_tuples(caplog, name, level, message, expected):
+    logger.info('foo %s', 'arg')
+    logger.info('bar %s', 'arg')
+
+    filtered = caplog.filter_record_tuples(name, level, message)
+    filtered_named_args = caplog.filter_record_tuples(name=name, level=level, message=message)
+
+    assert filtered == filtered_named_args
+    assert [f[2].split(' ')[0] for f in filtered] == expected
 
 
 def test_unicode(caplog):

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -113,9 +113,13 @@ def test_levels(caplog, level):
     assert getattr(caplog, level) == getattr(logging, level)
 
 
-def test_levels_error(caplog):
+@pytest.mark.parametrize('level', [
+    'UNKNOWNLEVEL',  # Matches log level pattern, looked up from logging module.
+    'something_else'  # Not looked up from logging. Not an attribute of LogCaptureFixture.
+])
+def test_levels_error(caplog, level):
     with pytest.raises(AttributeError):
-        getattr(caplog, 'UNKNOWNLEVEL')
+        getattr(caplog, level)
 
 
 def test_unicode(caplog):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
-# Note: Disabled pypy3 due to currently being broken on travis-ci.
-# See: https://github.com/travis-ci/travis-ci/issues/6277#issuecomment-265128578
-envlist = py{26,27,33,34,35}, pypy, perf
+envlist = py{26,27,33,34,35}, pypy{,3}, perf
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py{26,27,33,34,35}, pypy{,3}, perf
+# Note: Disabled pypy3 due to currently being broken on travis-ci.
+# See: https://github.com/travis-ci/travis-ci/issues/6277#issuecomment-265128578
+envlist = py{26,27,33,34,35}, pypy, perf
 
 [testenv]
 deps =


### PR DESCRIPTION
I find myself often using the following construct when asserting if a certain log message has been recorded:

```py
import logging

def test_things(caplog):
    # things
    assert list(filter(lambda r: r[0] == 'my.module' and r[1] == logging.WARNING, caplog.record_tuples))
``` 

Some of the drawbacks:
* Lot of repetition of constructs not part of the test, e.g. the need to wrap the filter result in list to be able to assert the length
* Need to import logging merely to obtain the log level

I propose an extension to caplog that looks like this:

```py
def test_things(caplog):
    # things
    assert caplog.filter_record_tuples('my.module', caplog.WARNING)
``` 

Please let me know your thoughts. Do I need to create an issue for this proposal?

Edit: 
* Changed ``caplogs.levels.WARNING`` into ``caplog.WARNING``
* Removed references to deprecated 'WARN' (Will not include it in levels exposed)
* Removed 'Work in Progress' from PR