### PR TITLE
Replace item.add_report_section() with long_repr.addsection()

### DIFF
--- a/pytest_catchlog/common.py
+++ b/pytest_catchlog/common.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function
 
 import logging
-from contextlib import closing, contextmanager
+from contextlib import contextmanager
 
 import py
 
@@ -59,8 +59,6 @@ def catching_logs(handler, filter=None, formatter=None,
         handler.setFormatter(formatter)
     handler.setLevel(level)
 
-    with closing(handler):
-        with logging_using_handler(handler, logger):
-            with logging_at_level(min(handler.level, logger.level), logger):
-
-                yield handler
+    with logging_using_handler(handler, logger):
+        with logging_at_level(min(handler.level, logger.level), logger):
+            yield handler

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -60,9 +60,7 @@ def test_setup_logging(testdir):
         ''')
     result = testdir.runpytest()
     assert result.ret == 1
-    result.stdout.fnmatch_lines(['*- Captured *log setup -*',
-                                 '*text going to logger from setup*',
-                                 '*- Captured *log call -*',
+    result.stdout.fnmatch_lines(['*- Captured *log call -*',
                                  '*text going to logger from call*'])
 
 
@@ -81,9 +79,7 @@ def test_teardown_logging(testdir):
         ''')
     result = testdir.runpytest()
     assert result.ret == 1
-    result.stdout.fnmatch_lines(['*- Captured *log call -*',
-                                 '*text going to logger from call*',
-                                 '*- Captured *log teardown -*',
+    result.stdout.fnmatch_lines(['*- Captured *log teardown -*',
                                  '*text going to logger from teardown*'])
 
 


### PR DESCRIPTION
Commit cfedc4 does the reverse change and introduces the following bug.
When used together with pytest junitxml option, the XML report does not
contain the captured log output, since junit-xml does not know about
the 'log' section.

I am not happy to post this change but this exact change was the one that broke
the logs of junitxml in first place. Please let me know what you think, or if you
can propose some other solution to this problem.

PR https://github.com/eisensheng/pytest-catchlog/pull/39 addresses the same
issue so if you 're more comfortable with that I can rebase it and resend it.