### PR TITLE
Swallow error messages when the stream is closed.

### DIFF
--- a/pytest_catchlog/plugin.py
+++ b/pytest_catchlog/plugin.py
@@ -262,3 +262,11 @@ class LogCaptureHandler(logging.StreamHandler):
 
         self.records.append(record)
         logging.StreamHandler.emit(self, record)
+        
+    def handleError(self, record):
+        """Handle error"""
+        ei = sys.exc_info()
+        if ei[0] == ValueError and self.stream.closed:
+            # Swallow errors when the stream is closed.
+            return
+        return logging.StreamHandler.handleError(self, record)


### PR DESCRIPTION
This is a fix for #43 as suggested in the comments.

I didn't remove the ``closing()`` context manager, doesn't seem necessary, as just swallowing the error should be enough.

This does point out that ``pytest-catchlog`` could do something smarter in ``.handleError()`` and report that back in the pytest results.