### PR TITLE
Fix set_level side effects

### DIFF
--- a/pytest_catchlog/fixture.py
+++ b/pytest_catchlog/fixture.py
@@ -13,9 +13,10 @@ from pytest_catchlog.common import catching_logs, logging_at_level
 class LogCaptureFixture(object):
     """Provides access and control of log capturing."""
 
-    def __init__(self, item):
+    def __init__(self, item, monkeypatch):
         """Creates a new funcarg."""
         self._item = item
+        self._monkeypatch = monkeypatch
 
     @property
     def handler(self):
@@ -55,7 +56,7 @@ class LogCaptureFixture(object):
         """
 
         obj = logger and logging.getLogger(logger) or self.handler
-        obj.setLevel(level)
+        self._monkeypatch.setattr(obj, 'level', logging._checkLevel(level))
 
     def at_level(self, level, logger=None):
         """Context manager that sets the level for capturing of logs.
@@ -140,7 +141,7 @@ class CompatLogCaptureFixture(LogCaptureFixture):
 
 
 @pytest.fixture
-def caplog(request):
+def caplog(request, monkeypatch):
     """Access and control log capturing.
 
     Captured logs are available through the following methods::
@@ -149,6 +150,6 @@ def caplog(request):
     * caplog.records()       -> list of logging.LogRecord instances
     * caplog.record_tuples() -> list of (logger_name, level, message) tuples
     """
-    return CompatLogCaptureFixture(request.node)
+    return CompatLogCaptureFixture(request.node, monkeypatch)
 
 capturelog = caplog

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -14,11 +14,12 @@ def test_fixture_help(testdir):
     result.stdout.fnmatch_lines(['*caplog*'])
 
 
-def test_change_level(caplog):
+def test_change_level(caplog, monkeypatch):
     caplog.set_level(logging.INFO)
     logger.debug('handler DEBUG level')
     logger.info('handler INFO level')
 
+    assert sublogger.level == logging.NOTSET
     caplog.set_level(logging.CRITICAL, logger=sublogger.name)
     sublogger.warning('logger WARNING level')
     sublogger.critical('logger CRITICAL level')
@@ -27,6 +28,9 @@ def test_change_level(caplog):
     assert 'INFO' in caplog.text
     assert 'WARNING' not in caplog.text
     assert 'CRITICAL' in caplog.text
+    assert sublogger.level == logging.CRITICAL
+    monkeypatch.undo()
+    assert sublogger.level == logging.NOTSET
 
 
 def test_with_statement(caplog):


### PR DESCRIPTION
On test case completion all modifications to loggers levels are reversed.

Fixes #60 